### PR TITLE
fixed myprofile still using old username on second login and added test cases for make post and landing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,18 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.20.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/interface_adapter/logout/LogoutPresenter.java
+++ b/src/main/java/interface_adapter/logout/LogoutPresenter.java
@@ -27,8 +27,8 @@ public class LogoutPresenter implements LogoutOutputBoundary {
         MyProfileState myProfileState  = this.myProfileViewModel.getState();
         String oldUsername = myProfileState.getUsername();
         myProfileState.logout();
-
-        this.myProfileViewModel.firePropertyChange();
+        myProfileState.setInactive();
+        myProfileViewModel.setState(myProfileState);
 
         LoginState loginState = this.loginSignupViewModel.getState();
         loginState.setUsername(oldUsername);

--- a/src/main/java/interface_adapter/my_profile/MyProfilePresenter.java
+++ b/src/main/java/interface_adapter/my_profile/MyProfilePresenter.java
@@ -28,13 +28,13 @@ public class MyProfilePresenter implements MyProfileOutputBoundary {
     }
 
     @Override
-    public void prepareSuccessView(MyProfileOutputData makePostOutputData) {
+    public void prepareSuccessView(MyProfileOutputData myProfileOutputData) {
         MyProfileState state = myProfileViewModel.getState();
-        state.setUsername(makePostOutputData.getUsername());
-        state.setPassword(makePostOutputData.getPassword());
-        state.setEmail(makePostOutputData.getEmail());
-        state.setBio(makePostOutputData.getBio());
-        state.setPosts(makePostOutputData.getPosts());
+        state.setUsername(myProfileOutputData.getUsername());
+        state.setPassword(myProfileOutputData.getPassword());
+        state.setEmail(myProfileOutputData.getEmail());
+        state.setBio(myProfileOutputData.getBio());
+        state.setPosts(myProfileOutputData.getPosts());
         myProfileViewModel.setState(state);
         myProfileViewModel.firePropertyChange();
     }

--- a/src/test/java/use_case/landing/LandingTests.java
+++ b/src/test/java/use_case/landing/LandingTests.java
@@ -1,4 +1,137 @@
 package use_case.landing;
 
+import entity.Post;
+import entity.User;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import use_case.make_post.PostViewData;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.*;
+
 public class LandingTests {
+
+    private LandingDataAccessInterface landingDataAccess;
+    private LandingOutputBoundary landingPresenter;
+    private LandingInteractor interactor;
+
+    @Before
+    public void setUp() {
+        landingDataAccess = Mockito.mock(LandingDataAccessInterface.class);
+        landingPresenter  = Mockito.mock(LandingOutputBoundary.class);
+        interactor        = new LandingInteractor(landingDataAccess, landingPresenter);
+    }
+
+    // 1) Happy path: one user with posts
+    @Test
+    public void oneUserWithPosts_returnsNewestPostOnce() {
+        ArrayList<String> usernames = new ArrayList<>();
+        usernames.add("alice");
+
+        // user with TWO posts, so "newest" is the SECOND (last) one
+        User alice = new User("alice", "pw", "alice@email", "Alice");
+        alice.getPosts().add(new Post(1, "alice", "old", "body1", "d1"));
+        Post newest = new Post(2, "alice", "new", "body2", "d2");
+        alice.getPosts().add(newest);
+
+        Mockito.when(landingDataAccess.getExistingUsernames()).thenReturn(usernames);
+        Mockito.when(landingDataAccess.getUserInfo("alice")).thenReturn(alice);
+
+        interactor.execute();
+
+        ArgumentCaptor<LandingOutputData> cap =
+                ArgumentCaptor.forClass(LandingOutputData.class);
+        Mockito.verify(landingPresenter).prepareSuccessView(cap.capture());
+
+        ArrayList<PostViewData> resultPosts = cap.getValue().getPosts();
+        // with a single username, we’ll end up with exactly one post
+        assertEquals(1, resultPosts.size());
+
+        PostViewData p = resultPosts.get(0);
+        assertEquals("alice", p.getUsername());
+        assertEquals(2,       p.getPost_id());
+        assertEquals("new",   p.getTitle());
+        assertEquals("body2", p.getBody());
+        assertEquals("d2",    p.getPost_date());
+    }
+
+    // 2) User has NO posts → nothing added, but still success
+    @Test
+    public void userWithNoPosts_resultsInEmptyList() {
+        ArrayList<String> usernames = new ArrayList<>();
+        usernames.add("bob");
+
+        User bob = new User("bob", "pw", "bob@email", "Bob");
+        // bob.getPosts() is empty
+
+        Mockito.when(landingDataAccess.getExistingUsernames()).thenReturn(usernames);
+        Mockito.when(landingDataAccess.getUserInfo("bob")).thenReturn(bob);
+
+        interactor.execute();
+
+        ArgumentCaptor<LandingOutputData> cap =
+                ArgumentCaptor.forClass(LandingOutputData.class);
+        Mockito.verify(landingPresenter).prepareSuccessView(cap.capture());
+
+        ArrayList<PostViewData> resultPosts = cap.getValue().getPosts();
+        assertTrue(resultPosts.isEmpty());
+    }
+
+    // 3) Data access throws → fail view called
+    @Test
+    public void exceptionInDataAccess_callsFailView() {
+        Mockito.when(landingDataAccess.getExistingUsernames())
+                .thenThrow(new RuntimeException("boom"));
+
+        interactor.execute();
+
+        Mockito.verify(landingPresenter)
+                .prepareFailView("boom");
+        // and success view should NOT be called
+        Mockito.verify(landingPresenter, Mockito.never())
+                .prepareSuccessView(Mockito.any());
+    }
+
+    // 4) Optional: multiple users, invariants only (no duplicates, <=3 posts)
+    @Test
+    public void multipleUsers_neverDuplicatesUsernames_andUpToThreePosts() {
+        ArrayList<String> usernames = new ArrayList<>();
+        usernames.add("alice");
+        usernames.add("bob");
+        usernames.add("carol");
+
+        User alice = new User("alice", "pw", "a@email", "Alice");
+        alice.getPosts().add(new Post(1, "alice", "a1", "b1", "d1"));
+
+        User bob = new User("bob", "pw", "b@email", "Bob");
+        bob.getPosts().add(new Post(2, "bob", "b1", "b2", "d2"));
+
+        User carol = new User("carol", "pw", "c@email", "Carol");
+        carol.getPosts().add(new Post(3, "carol", "c1", "c2", "d3"));
+
+        Mockito.when(landingDataAccess.getExistingUsernames()).thenReturn(usernames);
+        Mockito.when(landingDataAccess.getUserInfo("alice")).thenReturn(alice);
+        Mockito.when(landingDataAccess.getUserInfo("bob")).thenReturn(bob);
+        Mockito.when(landingDataAccess.getUserInfo("carol")).thenReturn(carol);
+
+        interactor.execute();
+
+        ArgumentCaptor<LandingOutputData> cap =
+                ArgumentCaptor.forClass(LandingOutputData.class);
+        Mockito.verify(landingPresenter).prepareSuccessView(cap.capture());
+
+        ArrayList<PostViewData> resultPosts = cap.getValue().getPosts();
+
+        // size is 1..3 because of randomness & while-condition
+        assertTrue(resultPosts.size() >= 1 && resultPosts.size() <= 3);
+
+        // usernames are unique
+        java.util.Set<String> names = new java.util.HashSet<>();
+        for (PostViewData p : resultPosts) {
+            assertTrue("duplicate username in posts", names.add(p.getUsername()));
+        }
+    }
 }

--- a/src/test/java/use_case/landing/LandingTests.java
+++ b/src/test/java/use_case/landing/LandingTests.java
@@ -1,0 +1,4 @@
+package use_case.landing;
+
+public class LandingTests {
+}

--- a/src/test/java/use_case/make_post/MakePostTests.java
+++ b/src/test/java/use_case/make_post/MakePostTests.java
@@ -1,4 +1,163 @@
 package use_case.make_post;
 
+import entity.*;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.mockito.Mockito;
+import org.mockito.ArgumentCaptor;
+
+import java.util.ArrayList;
+
+
 public class MakePostTests {
+
+    private MakePostUserDataAccessInterface userGateway;
+    private MakePostOutputBoundary presenter;
+    private PostFactory postFactory;
+    private MakePostInteractor interactor;
+    private UserFactory userFactory;
+
+    @Before
+    public void setUp() {
+        userGateway = Mockito.mock(MakePostUserDataAccessInterface.class);
+        presenter = Mockito.mock(MakePostOutputBoundary.class);
+        postFactory = Mockito.mock(PostFactory.class);
+        userFactory = Mockito.mock(UserFactory.class);
+        interactor = new MakePostInteractor(userGateway, presenter, userFactory, postFactory);
+    }
+
+    @Test
+    public void blankTitle_callsFailView_andStops() {
+        MakePostInputData in = new MakePostInputData("alice", "", "body");
+
+        interactor.execute(in);
+
+        Mockito.verify(presenter)
+                .prepareFailView("Title or Body cannot be blank");
+        Mockito.verifyNoInteractions(userGateway, postFactory);
+    }
+
+    @Test
+    public void blankBody_callsFailView_andStops() {
+        MakePostInputData in = new MakePostInputData("alice", "title", "");
+
+        interactor.execute(in);
+
+        Mockito.verify(presenter)
+                .prepareFailView("Title or Body cannot be blank");
+        Mockito.verifyNoInteractions(userGateway, postFactory);
+    }
+
+    @Test
+    public void userNotFound_callsFailView() {
+        MakePostInputData in = new MakePostInputData("alice", "t", "b");
+        Mockito.when(userGateway.getUserInfo("alice")).thenReturn(null);
+
+        interactor.execute(in);
+
+        Mockito.verify(presenter).prepareFailView("User not found.");
+        Mockito.verify(userGateway, Mockito.never()).save(Mockito.any());
+    }
+
+    @Test
+    public void exceptionLoadingUser_callsFailView() {
+        MakePostInputData in = new MakePostInputData("alice", "t", "b");
+        Mockito.when(userGateway.getUserInfo("alice"))
+                .thenThrow(new RuntimeException("db down"));
+
+        interactor.execute(in);
+
+        Mockito.verify(presenter)
+                .prepareFailView(Mockito.startsWith("Failed to load user: "));
+    }
+
+    @Test
+    public void happyPath_createsPostWithMaxIdPlusOne_andCallsSuccess() {
+        // input
+        MakePostInputData in =
+                new MakePostInputData("alice", "new title", "new body");
+
+        User user = new User("alice", "pw", "alice@email.com", "Alice");
+
+        // first post: id 3  -> maxId becomes 3 (if condition TRUE)
+        Post post1 = new Post(3, "alice", "old1", "old body1", "t1");
+        // second post: id 1 -> 1 > 3 is FALSE, so branch FALSE is hit
+        Post post2 = new Post(1, "alice", "old2", "old body2", "t2");
+
+        user.getPosts().add(post1);
+        user.getPosts().add(post2);
+
+        Mockito.when(userGateway.getUserInfo("alice")).thenReturn(user);
+
+        // post that the factory will create (id should be 4 = maxId+1)
+        Post created = new Post(
+                4,                   // post_id
+                "alice",
+                "new title",
+                "new body",
+                "t2"
+        );
+        Mockito.when(postFactory.create(
+                Mockito.eq("alice"),
+                Mockito.eq(4),
+                Mockito.eq("new title"),
+                Mockito.eq("new body"),
+                Mockito.anyString()   // time from Instant.now().toString()
+        )).thenReturn(created);
+
+        // run
+        interactor.execute(in);
+
+        // user should be saved
+        Mockito.verify(userGateway).save(user);
+
+        // presenter should receive correct view data
+        ArgumentCaptor<MakePostOutputData> cap =
+                ArgumentCaptor.forClass(MakePostOutputData.class);
+        Mockito.verify(presenter).prepareSuccessView(cap.capture());
+
+        PostViewData view = cap.getValue().getNewPost();
+        assertEquals("username mismatch", "alice", view.getUsername());
+        assertEquals("post id mismatch", 4, view.getPost_id());
+        assertEquals("title mismatch", "new title", view.getTitle());
+
+    }
+
+    @Test
+    public void exceptionSavingUser_callsFailView() {
+        MakePostInputData in = new MakePostInputData("alice", "t", "b");
+
+        User user = new User("alice", "pw", "alice@email.com", "Alice");
+        Mockito.when(userGateway.getUserInfo("alice")).thenReturn(user);
+
+        Mockito.when(postFactory.create(
+                Mockito.anyString(),
+                Mockito.anyInt(),
+                Mockito.anyString(),
+                Mockito.anyString(),
+                Mockito.anyString()
+        )).thenReturn(new Post(1, "alice", "t", "b", "t"));
+
+        Mockito.doThrow(new RuntimeException("disk full"))
+                .when(userGateway).save(user);
+
+        interactor.execute(in);
+
+        Mockito.verify(presenter)
+                .prepareFailView(Mockito.startsWith("Failed to save user: "));
+    }
+
+    @Test
+    public void postViewData_gettersWork() {
+        ArrayList<Comment> comments = new ArrayList<>();
+        PostViewData dto = new PostViewData("alice", 4, "t", "b", "date", comments);
+
+        assertEquals("alice", dto.getUsername());
+        assertEquals(4, dto.getPost_id());
+        assertEquals("t", dto.getTitle());
+        assertEquals("b", dto.getBody());
+        assertEquals("date", dto.getPost_date());
+        assertSame(comments, dto.getComments());
+    }
 }

--- a/src/test/java/use_case/make_post/MakePostTests.java
+++ b/src/test/java/use_case/make_post/MakePostTests.java
@@ -1,0 +1,4 @@
+package use_case.make_post;
+
+public class MakePostTests {
+}


### PR DESCRIPTION
`isactive` of `myprofilestate` wasn't set to `false` on logout

added test cases with 100% coverage on the interactor `execute()` of make post and landing

also changed a variable naming problem in `myprofilepresenter`